### PR TITLE
Update CutImage.cs

### DIFF
--- a/src/WPFDevelopers/Controls/CutImage/CutImage.cs
+++ b/src/WPFDevelopers/Controls/CutImage/CutImage.cs
@@ -19,7 +19,9 @@ namespace WPFDevelopers.Controls
         public ImageSource ImageSource
         {
             get { return (ImageSource)GetValue(ImageSourceProperty); }
-            set { SetValue(ImageSourceProperty, value); }
+            set { SetValue(ImageSourceProperty, value); 
+                   DragDropItem_UpdateImageEvent();
+            }
         }
 
         public static readonly DependencyProperty ImageSourceProperty =


### PR DESCRIPTION
在加载图片时，默认获取剪切到的图片，符合一般市面上的切图软件逻辑，同时防止加载图片完点保存报空引用的错误。