### PR TITLE
[优化]-截图功能图片精度调整

### DIFF
--- a/src/WPFDevelopers.Shared/Controls/ScreenCut/ScreenCut.cs
+++ b/src/WPFDevelopers.Shared/Controls/ScreenCut/ScreenCut.cs
@@ -448,11 +448,19 @@ namespace WPFDevelopers.Controls
             _rectangleTop.Visibility = Visibility.Collapsed;
             _rectangleRight.Visibility = Visibility.Collapsed;
             _rectangleBottom.Visibility = Visibility.Collapsed;
-            var renderTargetBitmap = new RenderTargetBitmap((int)_canvas.Width,
-                (int)_canvas.Height, 96d, 96d, PixelFormats.Default);
+            // 屏幕等比截图需要考虑缩放率进行等比放大canvas
+            var renderTargetBitmap = new RenderTargetBitmap((int)(_canvas.Width * screenDPI.scaleX),
+                (int)(_canvas.Height * screenDPI.scaleY), screenDPI.dpiX, screenDPI.dpiY, PixelFormats.Default);
             renderTargetBitmap.Render(_canvas);
-            return new CroppedBitmap(renderTargetBitmap,
-                new Int32Rect((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height));
+            // 屏幕等比截图需要考虑缩放率进行等比放大截图区域
+            var realrect = new Int32Rect(
+                (int)(rect.X * screenDPI.scaleX),
+                (int)(rect.Y * screenDPI.scaleY),
+                (int)(rect.Width * screenDPI.scaleX),
+                (int)(rect.Height * screenDPI.scaleY));
+            //return new CroppedBitmap(renderTargetBitmap,
+            //    new Int32Rect((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height));
+            return new CroppedBitmap(renderTargetBitmap, realrect);
         }
         
         private void ButtonCancel_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
细微调整了一下截图功能中截图下载截图图片，因屏幕缩放率导致真实截图与界面所见即所得图像之间的差异
现有效果：
![image](https://github.com/WPFDevelopersOrg/WPFDevelopers/assets/25916858/bce7adc2-7bd3-4601-a67d-f8d72de7a03f)
微信截图：
![image](https://github.com/WPFDevelopersOrg/WPFDevelopers/assets/25916858/8041bceb-1914-4201-aeff-392e82e988f6)
