### PR TITLE
Bug Fixed: When MessageBoxButton set to YesNo, There will be more one OK Button.

### DIFF
--- a/src/WPFDevelopers.Shared/Controls/MessageBox/WDMessageBox.cs
+++ b/src/WPFDevelopers.Shared/Controls/MessageBox/WDMessageBox.cs
@@ -202,10 +202,13 @@ namespace WPFDevelopers.Controls
                     _okVisibility = Visibility.Visible;
                     break;
                 case MessageBoxButton.YesNo:
+                    _okVisibility = Visibility.Hidden;
+                    _cancelVisibility = Visibility.Hidden;
                     _yesVisibility = Visibility.Visible;
                     _noVisibility = Visibility.Visible;
                     break;
                 case MessageBoxButton.YesNoCancel:
+                    _okVisibility = Visibility.Hidden;
                     _yesVisibility = Visibility.Visible;
                     _noVisibility = Visibility.Visible;
                     _cancelVisibility = Visibility.Visible;


### PR DESCRIPTION
As the title says.
```cs
var result = MessageBox.Show("确定删除该用户吗？", "提示", MessageBoxButton.YesNo, MessageBoxImage.Question, null, 5);
if (result != MessageBoxResult.Yes)
{
    return;
}
```
Then, You will get a MessgaeBox like this.
![image](https://github.com/user-attachments/assets/960ebeac-796b-4985-b11c-74c4d901185b)

Set ok and cancel button Visibility will works.
![image](https://github.com/user-attachments/assets/bb0e9746-8bad-4722-8135-64498a9a1850)

