### PR TITLE
Bug Fixed: When MessageBoxButton set to YesNo Or YesNoCancel, There will be more one OK Button.

### DIFF
--- a/src/WPFDevelopers.Shared/Controls/MessageBox/WDMessageBox.cs
+++ b/src/WPFDevelopers.Shared/Controls/MessageBox/WDMessageBox.cs
@@ -217,10 +217,13 @@ namespace WPFDevelopers.Controls
                     _okVisibility = Visibility.Visible;
                     break;
                 case MessageBoxButton.YesNo:
+                    _okVisibility = Visibility.Collapsed;
+                    _cancelVisibility = Visibility.Collapsed;
                     _yesVisibility = Visibility.Visible;
                     _noVisibility = Visibility.Visible;
                     break;
                 case MessageBoxButton.YesNoCancel:
+                    _okVisibility = Visibility.Collapsed;
                     _yesVisibility = Visibility.Visible;
                     _noVisibility = Visibility.Visible;
                     _cancelVisibility = Visibility.Visible;


### PR DESCRIPTION
As the title says.
```cs
var result = MessageBox.Show("确定删除该用户吗？", "提示", MessageBoxButton.YesNo, MessageBoxImage.Question, null, 5);
// or var result = MessageBox.Show("确定删除该用户吗？", "提示", MessageBoxButton.YesNoCancel, MessageBoxImage.Question, null, 5);
if (result != MessageBoxResult.Yes)
{
    return;
}
```
Then, You will get a MessgaeBox like this.
![image](https://github.com/user-attachments/assets/960ebeac-796b-4985-b11c-74c4d901185b)
![image](https://github.com/user-attachments/assets/90504b9f-e15e-4903-880c-57593cc9ad9c)


Set ok and cancel button Visibility will works.
![image](https://github.com/user-attachments/assets/f2adb8c7-a93e-4182-afcd-ecc86f19e5e9)
![image](https://github.com/user-attachments/assets/b9a0d089-907c-4a55-89ca-243538947ba0)

